### PR TITLE
Adding support for slip and sliprand to central mesh file

### DIFF
--- a/lib/perfSONAR_PS/MeshConfig/Config/TestParameters/PerfSONARBUOYBwctl.pm
+++ b/lib/perfSONAR_PS/MeshConfig/Config/TestParameters/PerfSONARBUOYBwctl.pm
@@ -36,6 +36,8 @@ has 'ipv4_only'       => (is => 'rw', isa => 'Bool');
 has 'ipv6_only'       => (is => 'rw', isa => 'Bool');
 has 'latest_time'     => (is => 'rw', isa => 'Int');
 has 'random_start_percentage' => (is => 'rw', isa => 'Int');
+has 'slip' => (is => 'rw', isa => 'Int');
+has 'slip_randomize' => (is => 'rw', isa => 'Bool');
 has 'time_slots'   => (is => 'rw', isa => 'ArrayRef[Str]');
 #new pscheduler fields
 has 'tcp_bandwidth' => (is => 'rw', isa => 'Int');

--- a/lib/perfSONAR_PS/MeshConfig/Config/TestParameters/PingER.pm
+++ b/lib/perfSONAR_PS/MeshConfig/Config/TestParameters/PingER.pm
@@ -29,6 +29,8 @@ has 'ipv4_only'       => (is => 'rw', isa => 'Bool');
 has 'ipv6_only'       => (is => 'rw', isa => 'Bool');
 has 'force_bidirectional' => (is => 'rw', isa => 'Bool');
 has 'random_start_percentage' => (is => 'rw', isa => 'Int');
+has 'slip' => (is => 'rw', isa => 'Int');
+has 'slip_randomize' => (is => 'rw', isa => 'Bool');
 #new pscheduler fields
 has 'flowlabel' => (is => 'rw', isa => 'Int');
 has 'hostnames' => (is => 'rw', isa => 'Bool');

--- a/lib/perfSONAR_PS/MeshConfig/Config/TestParameters/SimpleStream.pm
+++ b/lib/perfSONAR_PS/MeshConfig/Config/TestParameters/SimpleStream.pm
@@ -28,6 +28,8 @@ has 'timeout'                   => (is => 'rw', isa => 'Int',);
 has 'tool' => (is => 'rw', isa => 'Str');
 has 'force_bidirectional'       => (is => 'rw', isa => 'Bool');
 has 'random_start_percentage'   => (is => 'rw', isa => 'Int');
+has 'slip' => (is => 'rw', isa => 'Int');
+has 'slip_randomize' => (is => 'rw', isa => 'Bool');
 has 'interval'                  => (is => 'rw', isa => 'Int');
 has 'ipv4_only'       => (is => 'rw', isa => 'Bool');
 has 'ipv6_only'       => (is => 'rw', isa => 'Bool');

--- a/lib/perfSONAR_PS/MeshConfig/Config/TestParameters/Traceroute.pm
+++ b/lib/perfSONAR_PS/MeshConfig/Config/TestParameters/Traceroute.pm
@@ -33,6 +33,8 @@ has 'ipv4_only'       => (is => 'rw', isa => 'Bool');
 has 'ipv6_only'       => (is => 'rw', isa => 'Bool');
 has 'force_bidirectional' => (is => 'rw', isa => 'Bool');
 has 'random_start_percentage' => (is => 'rw', isa => 'Int');
+has 'slip' => (is => 'rw', isa => 'Int');
+has 'slip_randomize' => (is => 'rw', isa => 'Bool');
 #new pscheduler fields
 has 'algorithm' => (is => 'rw', isa => 'Str');
 has 'as' => (is => 'rw', isa => 'Bool');

--- a/lib/perfSONAR_PS/MeshConfig/Generators/perfSONARRegularTesting.pm
+++ b/lib/perfSONAR_PS/MeshConfig/Generators/perfSONARRegularTesting.pm
@@ -464,6 +464,8 @@ sub __build_tests {
             $schedule   = perfSONAR_PS::RegularTesting::Schedulers::RegularInterval->new();
             $schedule->interval($test->parameters->test_interval);
             $schedule->random_start_percentage($test->parameters->random_start_percentage) if(defined $test->parameters->random_start_percentage);
+            $schedule->slip($test->parameters->slip) if(defined $test->parameters->slip);
+            $schedule->slip_randomize($test->parameters->slip_randomize) if(defined $test->parameters->slip_randomize);
         }
         elsif ($test->parameters->type eq "traceroute") {
             if($self->use_bwctl2){
@@ -492,6 +494,8 @@ sub __build_tests {
             $schedule   = perfSONAR_PS::RegularTesting::Schedulers::RegularInterval->new();
             $schedule->interval($test->parameters->test_interval) if $test->parameters->test_interval;
             $schedule->random_start_percentage($test->parameters->random_start_percentage) if(defined $test->parameters->random_start_percentage);
+            $schedule->slip($test->parameters->slip) if(defined $test->parameters->slip);
+            $schedule->slip_randomize($test->parameters->slip_randomize) if(defined $test->parameters->slip_randomize);
         }
         elsif ($test->parameters->type eq "perfsonarbuoy/bwctl") {
             if($self->use_bwctl2){
@@ -534,6 +538,8 @@ sub __build_tests {
 				$schedule   = perfSONAR_PS::RegularTesting::Schedulers::RegularInterval->new();
             	$schedule->interval($test->parameters->interval) if $test->parameters->interval;
             	$schedule->random_start_percentage($test->parameters->random_start_percentage) if(defined $test->parameters->random_start_percentage);
+            	$schedule->slip($test->parameters->slip) if(defined $test->parameters->slip);
+            	$schedule->slip_randomize($test->parameters->slip_randomize) if(defined $test->parameters->slip_randomize);
 			}
         }
         elsif ($test->parameters->type eq "perfsonarbuoy/owamp") {
@@ -571,6 +577,8 @@ sub __build_tests {
 			$schedule = perfSONAR_PS::RegularTesting::Schedulers::RegularInterval->new();
             $schedule->interval($test->parameters->interval) if $test->parameters->interval;
             $schedule->random_start_percentage($test->parameters->random_start_percentage) if(defined $test->parameters->random_start_percentage);
+            $schedule->slip($test->parameters->slip) if(defined $test->parameters->slip);
+            $schedule->slip_randomize($test->parameters->slip_randomize) if(defined $test->parameters->slip_randomize);
         }
 
         if ($target_sends and not $target_receives) {


### PR DESCRIPTION
This adds the ability to explicitly set slip and sliprand in the central mesh file. Merge this along with the perl-shared pull request when you want to test out the changes.This particular pull request doesn't do much, it just adds support for new options that don't actually need to be set. The meat of the changes is in the perl-shared pull request.