### PR TITLE
Handle UTF-8 characters in meshconfig-agent-tasks.conf

### DIFF
--- a/lib/perfSONAR_PS/MeshConfig/Agent.pm
+++ b/lib/perfSONAR_PS/MeshConfig/Agent.pm
@@ -469,7 +469,7 @@ sub __write_file {
     $logger->debug("Writing ".$file);
 
     eval {
-        open(FILE, ">".$file) or die("Couldn't open $file");
+        open(FILE, ">:encoding(UTF-8)", $file) or die("Couldn't open $file");
         print FILE $contents;
         close(FILE);
     };
@@ -497,7 +497,7 @@ sub __compare_file {
 
     my $differ = 1;
 
-    if (open(FILE, $file)) {
+    if (open(FILE, "<:encoding(UTF-8)", $file)) {
         $logger->debug("Reading ".$file);
         my $file_contents = do { local $/; <FILE> };
         $differ = 0 if ($file_contents eq $contents);


### PR DESCRIPTION
Related to https://github.com/perfsonar/toolkit/issues/265 and going along with https://github.com/perfsonar/perl-shared/pull/41

Looks good for merging and further testing to me.